### PR TITLE
Hotfix/#8 Replace custom search endpoint with WP 5.0 search endpoint

### DIFF
--- a/class-wds-react-post-search.php
+++ b/class-wds-react-post-search.php
@@ -407,10 +407,6 @@ final class WDS_React_Post_Search {
 			endforeach;
 		endif;
 
-		if ( empty( $results ) ) :
-			return new WP_Error( 'wds-react-post-search-results', apply_filters( 'wds_react_post_search_no_results_text', esc_html__( 'No results found.', 'wds-react-post-search' ) ) );
-		endif;
-
 		return rest_ensure_response( $results );
 	}
 }

--- a/class-wds-react-post-search.php
+++ b/class-wds-react-post-search.php
@@ -249,7 +249,7 @@ final class WDS_React_Post_Search {
 		wp_enqueue_style( 'wds-react-post-search-styles' );
 
 		wp_localize_script( 'wds-react-post-search', 'wds_react_post_search', array(
-			'rest_search_posts'       => rest_url( 'wds-react-post-search/v1/search' ),
+			'rest_search_posts'       => rest_url( 'wp/v2/search' ),
 			'loading_text'            => apply_filters( 'wds_react_post_search_loading_text', esc_html__( 'Loading results...', 'wds-react-post-search' ) ),
 			'no_results_text'         => apply_filters( 'wds_react_post_search_no_results_text', esc_html__( 'No results found.', 'wds-react-post-search' ) ),
 			'length_error'            => apply_filters( 'wds_react_post_search_length_error_text', esc_html__( 'Please enter at least 3 characters.', 'wds-react-post-search' ) ),
@@ -329,7 +329,7 @@ final class WDS_React_Post_Search {
 	 * @return void
 	 */
 	public function rest_api_init() {
-		register_rest_route('wds-react-post-search/v1', '/search', [
+		register_rest_route( 'wp/v2', '/search', [
 			'methods'  => WP_REST_Server::READABLE,
 			'callback' => array( $this, 'search_posts' ),
 			'args'     => $this->get_search_args(),


### PR DESCRIPTION
Closes #8 

It looks like the issue might be coming from this commit: https://github.com/WebDevStudios/WDS-React-Post-Search/commit/605d490

With this chunk of code specifically: https://github.com/WebDevStudios/WDS-React-Post-Search/commit/605d490#diff-79e5a3319d8cd2b1598acd07d412f4a0R419

Basically, we're asking for an error message to be returned if there are no results found. If we remove this, the plugin still works as expected with returning the "No results found." text below the search input while also no longer showing a 500 error.

In addition, I've also updated our route to use `/wp/v2/` rather than our `/wds-react-post-search/v1/` and everything continues to work smoothly.

If y'all could give this a test on your locals and let me know if you run into anything, that'd be great!

With my testing:
- I no longer receive 500 errors when there are no search results found
- I still receive the expected "No results found." message when no search results are found
- I still receive the expected results when searching for a term